### PR TITLE
Modificación en el archivo readme & Issue#24: agregar variables en css para la paleta de colores

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ HTML
 CSS
 <br>
 Javascript
+<br>
 
 <br>
 Nombre: Martín Cosimano.

--- a/style.css
+++ b/style.css
@@ -16,6 +16,24 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+
+  /* Issue #24: Asignación de variables para la paleta de colores*/
+  --clr-primario-300: #C6E8EB;
+  --clr-primario-500: #72D5DC;
+  --clr-primario-700: #34C3CD;
+  --clr-primario-900: #00AFBB;
+
+  --clr-secundario-300: #86849E;
+  --clr-secundario-500: #304F4C;
+  --clr-sencudario-700: #1D426E;
+  --clr-secundario-900: #052D30;
+
+  --clr-neutro-300: #FFFFFF;
+  --clr-neutro-500: #C7C7C7;
+
+  --clr-transparencias: #00AFBB;
+  /* --------------------------------- */
+
 }
 
 a {


### PR DESCRIPTION
Tareas realizadas:

-En el archivo readme:
1.  Agregué una br para separar texto de bloque.

-En el archivo style.css:
1. Tomé la paleta de colores que el usuario julverTV compuso en Figma y compartió en el discord: https://discord.com/channels/1061300524936335360/1063901693063995657/1074055469720678540.
2. Organicé las variables en el root de acuerdo a su importancia y les otorgué valores numéricos para darles un orden, en donde el valor más bajo refiere a los colores más claros y el valor más alto a colores más oscuros.